### PR TITLE
Add support for Friends of Hue switches

### DIFF
--- a/src/main/java/io/github/zeroone3010/yahueapi/DimmerSwitch.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/DimmerSwitch.java
@@ -4,7 +4,7 @@ public interface DimmerSwitch extends Sensor {
   /**
    * The latest button event of this switch.
    *
-   * @return {@code true} if presence detected, {@code false} if not.
+   * @return the last button event.
    */
   DimmerSwitchButtonEvent getLatestButtonEvent();
 }

--- a/src/main/java/io/github/zeroone3010/yahueapi/FriendsOfHueSwitch.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/FriendsOfHueSwitch.java
@@ -1,0 +1,10 @@
+package io.github.zeroone3010.yahueapi;
+
+public interface FriendsOfHueSwitch extends Sensor {
+  /**
+   * The latest button event of this switch.
+   *
+   * @return the last button event.
+   */
+  FriendsOfHueSwitchButtonEvent getLatestButtonEvent();
+}

--- a/src/main/java/io/github/zeroone3010/yahueapi/FriendsOfHueSwitchButton.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/FriendsOfHueSwitchButton.java
@@ -1,0 +1,29 @@
+package io.github.zeroone3010.yahueapi;
+
+import java.util.stream.Stream;
+
+public enum FriendsOfHueSwitchButton {
+  LEFT_TOP(20),
+  LEFT_BOTTOM(21),
+  RIGHT_TOP(23),
+  RIGHT_BOTTOM(22),
+  TOP(101),
+  BOTTOM(99);
+
+  private final int buttonNumber;
+
+  FriendsOfHueSwitchButton(final int buttonNumber) {
+    this.buttonNumber = buttonNumber;
+  }
+
+  public int getButtonNumber() {
+    return buttonNumber;
+  }
+
+  static FriendsOfHueSwitchButton parseFromButtonEventCode(final int buttonEvent) {
+    return Stream.of(values())
+        .filter(value -> value.getButtonNumber() == buttonEvent)
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException("Cannot parse button event " + buttonEvent));
+  }
+}

--- a/src/main/java/io/github/zeroone3010/yahueapi/FriendsOfHueSwitchButtonEvent.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/FriendsOfHueSwitchButtonEvent.java
@@ -1,0 +1,25 @@
+package io.github.zeroone3010.yahueapi;
+
+public class FriendsOfHueSwitchButtonEvent {
+
+  final FriendsOfHueSwitchButton button;
+
+  FriendsOfHueSwitchButtonEvent(final FriendsOfHueSwitchButton button) {
+    this.button = button;
+  }
+
+  FriendsOfHueSwitchButtonEvent(final int buttonEventCode) {
+    this(FriendsOfHueSwitchButton.parseFromButtonEventCode(buttonEventCode));
+  }
+
+  public FriendsOfHueSwitchButton getButton() {
+    return button;
+  }
+
+  @Override
+  public String toString() {
+    return "FriendsOfHueSwitchButtonEvent{" +
+        "button=" + button +
+        '}';
+  }
+}

--- a/src/main/java/io/github/zeroone3010/yahueapi/FriendsOfHueSwitchImpl.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/FriendsOfHueSwitchImpl.java
@@ -1,0 +1,28 @@
+package io.github.zeroone3010.yahueapi;
+
+import io.github.zeroone3010.yahueapi.domain.SensorDto;
+
+import java.net.URL;
+import java.util.Map;
+import java.util.function.Supplier;
+
+final class FriendsOfHueSwitchImpl extends BasicSensor implements FriendsOfHueSwitch {
+
+  FriendsOfHueSwitchImpl(final String id, final SensorDto sensor, final URL url, final Supplier<Map<String, Object>> stateProvider) {
+    super(id, sensor, url, stateProvider);
+  }
+
+  @Override
+  public String toString() {
+    return "FriendsOfHueSwitch{" +
+        "id='" + super.id + '\'' +
+        ", name='" + super.name + '\'' +
+        ", type=" + super.type +
+        '}';
+  }
+
+  @Override
+  public FriendsOfHueSwitchButtonEvent getLatestButtonEvent() {
+    return new FriendsOfHueSwitchButtonEvent(readStateValue("buttonevent", Integer.class));
+  }
+}

--- a/src/main/java/io/github/zeroone3010/yahueapi/Hue.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/Hue.java
@@ -296,6 +296,16 @@ public final class Hue {
   }
 
   /**
+   * Returns all the Friends of Hue switches configured into the Bridge.
+   *
+   * @return A Collection of dimmer switches.
+   * @since 1.0.0
+   */
+  public Collection<FriendsOfHueSwitch> getFriendsOfHueSwitches() {
+    return getSensorsByType(SensorType.FOH_SWITCH, FriendsOfHueSwitch.class);
+  }
+
+  /**
    * Returns all the motion sensors configured into the Bridge.
    *
    * @return A Collection of motion sensors.

--- a/src/main/java/io/github/zeroone3010/yahueapi/SensorFactory.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/SensorFactory.java
@@ -36,6 +36,8 @@ final class SensorFactory {
         return new DaylightSensorImpl(id, sensor, url, stateProvider);
       case DIMMER_SWITCH:
         return new DimmerSwitchImpl(id, sensor, url, stateProvider);
+      case FOH_SWITCH:
+        return new FriendsOfHueSwitchImpl(id, sensor, url, stateProvider);
       default:
         return new BasicSensor(id, sensor, url, stateProvider);
     }

--- a/src/main/java/io/github/zeroone3010/yahueapi/SensorType.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/SensorType.java
@@ -20,6 +20,11 @@ public enum SensorType {
   DIMMER_SWITCH,
 
   /**
+   * A Friends of Hue switch.
+   */
+  FOH_SWITCH,
+
+  /**
    * A daylight sensor, i.e. the one in the Bridge.
    */
   DAYLIGHT,
@@ -45,6 +50,8 @@ public enum SensorType {
         return MOTION;
       case "zllswitch":
         return DIMMER_SWITCH;
+      case "zgpswitch":
+        return FOH_SWITCH;
       case "daylight":
         return DAYLIGHT;
       default:

--- a/src/test/java/io/github/zeroone3010/yahueapi/FriendsOfHueSwitchButtonEventTest.java
+++ b/src/test/java/io/github/zeroone3010/yahueapi/FriendsOfHueSwitchButtonEventTest.java
@@ -1,0 +1,14 @@
+package io.github.zeroone3010.yahueapi;
+
+import org.junit.jupiter.api.Test;
+
+import static io.github.zeroone3010.yahueapi.FriendsOfHueSwitchButton.BOTTOM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FriendsOfHueSwitchButtonEventTest {
+  @Test
+  void testInitializationByButtonEvent() {
+    final FriendsOfHueSwitchButtonEvent event = new FriendsOfHueSwitchButtonEvent(99);
+    assertEquals(BOTTOM, event.getButton());
+  }
+}

--- a/src/test/java/io/github/zeroone3010/yahueapi/FriendsOfHueSwitchButtonTest.java
+++ b/src/test/java/io/github/zeroone3010/yahueapi/FriendsOfHueSwitchButtonTest.java
@@ -1,0 +1,44 @@
+package io.github.zeroone3010.yahueapi;
+
+import org.junit.jupiter.api.Test;
+
+import static io.github.zeroone3010.yahueapi.FriendsOfHueSwitchButton.TOP;
+import static io.github.zeroone3010.yahueapi.FriendsOfHueSwitchButton.BOTTOM;
+import static io.github.zeroone3010.yahueapi.FriendsOfHueSwitchButton.LEFT_TOP;
+import static io.github.zeroone3010.yahueapi.FriendsOfHueSwitchButton.LEFT_BOTTOM;
+import static io.github.zeroone3010.yahueapi.FriendsOfHueSwitchButton.RIGHT_TOP;
+import static io.github.zeroone3010.yahueapi.FriendsOfHueSwitchButton.RIGHT_BOTTOM;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class FriendsOfHueSwitchButtonTest {
+  @Test
+  void shouldParseTop() {
+    assertEquals(TOP, FriendsOfHueSwitchButton.parseFromButtonEventCode(101));
+  }
+
+  @Test
+  void shouldParseBottom() {
+    assertEquals(BOTTOM, FriendsOfHueSwitchButton.parseFromButtonEventCode(99));
+  }
+
+  @Test
+  void shouldParseLeftTop() {
+    assertEquals(LEFT_TOP, FriendsOfHueSwitchButton.parseFromButtonEventCode(20));
+  }
+
+  @Test
+  void shouldParseLeftBottom() {
+    assertEquals(LEFT_BOTTOM, FriendsOfHueSwitchButton.parseFromButtonEventCode(21));
+  }
+
+  @Test
+  void shouldParseRightTop() {
+    assertEquals(RIGHT_TOP, FriendsOfHueSwitchButton.parseFromButtonEventCode(23));
+  }
+
+  @Test
+  void shouldParseRightBottom() {
+    assertEquals(RIGHT_BOTTOM, FriendsOfHueSwitchButton.parseFromButtonEventCode(22));
+  }
+
+}

--- a/src/test/java/io/github/zeroone3010/yahueapi/HueTest.java
+++ b/src/test/java/io/github/zeroone3010/yahueapi/HueTest.java
@@ -286,6 +286,15 @@ class HueTest {
   }
 
   @Test
+  void testGetFriendsOfHueSwitch() {
+    final Hue hue = createHueAndInitializeMockServer();
+    final Collection<FriendsOfHueSwitch> switches = hue.getFriendsOfHueSwitches()
+        .stream().filter(s -> s.getName().equals("Friends of Hue Switch"))
+        .collect(Collectors.toList());
+    assertEquals(1, switches.size());
+  }
+
+  @Test
   void testGetUnknownSensors() {
     final Hue hue = createHueAndInitializeMockServer();
     final Collection<Sensor> sensors = hue.getUnknownSensors();

--- a/src/test/java/io/github/zeroone3010/yahueapi/HueTestRun.java
+++ b/src/test/java/io/github/zeroone3010/yahueapi/HueTestRun.java
@@ -46,6 +46,10 @@ public class HueTestRun {
     hue.getZones().forEach(z -> System.out.println(String.format("\tZone '%s' has these lights: %s",
         z.getName(), z.getLights())));
 
+    System.out.println("\nFriends of Hue switches:");
+    hue.getFriendsOfHueSwitches().forEach(s -> System.out.println(String.format("\t%s (%s): %s",
+        s.getName(), s.getId(), s.getLatestButtonEvent())));
+
     System.out.println("\nMotion sensors:");
     hue.getMotionSensors().forEach(s -> System.out.println(String.format("\t%s (%s): Presence %s",
         s.getName(), s.getId(), s.isPresence())));

--- a/src/test/resources/hueRoot.json
+++ b/src/test/resources/hueRoot.json
@@ -689,6 +689,85 @@
         "certified": true
       }
     },
+    "5": {
+      "capabilities": {
+        "certified": true,
+        "inputs": [
+          {
+            "events": [
+              {
+                "buttonevent": 16,
+                "eventtype": "initial_press"
+              },
+              {
+                "buttonevent": 20,
+                "eventtype": "short_release"
+              }
+            ],
+            "repeatintervals": []
+          },
+          {
+            "events": [
+              {
+                "buttonevent": 17,
+                "eventtype": "initial_press"
+              },
+              {
+                "buttonevent": 21,
+                "eventtype": "short_release"
+              }
+            ],
+            "repeatintervals": []
+          },
+          {
+            "events": [
+              {
+                "buttonevent": 19,
+                "eventtype": "initial_press"
+              },
+              {
+                "buttonevent": 23,
+                "eventtype": "short_release"
+              }
+            ],
+            "repeatintervals": []
+          },
+          {
+            "events": [
+              {
+                "buttonevent": 18,
+                "eventtype": "initial_press"
+              },
+              {
+                "buttonevent": 22,
+                "eventtype": "short_release"
+              }
+            ],
+            "repeatintervals": []
+          }
+        ],
+        "primary": true
+      },
+      "config": {
+        "on": true
+      },
+      "manufacturername": "PhilipsFoH",
+      "modelid": "FOHSWITCH",
+      "name": "Friends of Hue Switch",
+      "productname": "Friends of Hue Switch",
+      "recycle": null,
+      "state": {
+        "buttonevent": 22,
+        "lastupdated": "2020-12-17T08:32:32"
+      },
+      "swupdate": {
+        "lastinstall": null,
+        "state": "notupdatable"
+      },
+      "swversion": null,
+      "type": "ZGPSwitch",
+      "uniqueid": "00:00:00:00:01:23:45:67-89"
+    },
     "15": {
       "state": {
         "temperature": 2953,


### PR DESCRIPTION
Hi @ZeroOne3010,

I've added support for Friends of Hue switches.
fixes https://github.com/ZeroOne3010/yetanotherhueapi/issues/22

First I implemented this change using the DimmerSwitch classes, but as there is no Action Code for the FOH switches, this feels a bit strange and I changed it to custom sensors.