### PR TITLE
Add Geofence sensor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,12 +12,11 @@ Unreleased
 This release contains breaking changes. This means that if you have been using a previous version of this library,
 you _may_ need to change your code to account for the changes in this version. See below for the details.
 
-* Added geofence support as motion sensors. They can be retrieved like all motion sensors with `getMotionSensors()` or `getMotionSensorByName(String)` with the name of a registered device.
-
 ### Added
 
 * Support for other kinds of switches than just the Philips Hue dimmer switches.
 * `getUnassignedLightByName(String)` method, to accompany the `getUnassignedLights()` method added in the previous release.
+* Added geofence support as motion sensors. They can be retrieved like all motion sensors with `getMotionSensors()` or `getMotionSensorByName(String)` with the name of a registered device.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ Unreleased
 This release contains breaking changes. This means that if you have been using a previous version of this library,
 you _may_ need to change your code to account for the changes in this version. See below for the details.
 
+* Added geofence support as motion sensors. They can be retrieved like all motion sensors with `getMotionSensors()` or `getMotionSensorByName(String)` with the name of a registered device.
+
 ### Added
 
 * Support for other kinds of switches than just the Philips Hue dimmer switches.

--- a/src/main/java/io/github/zeroone3010/yahueapi/Hue.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/Hue.java
@@ -297,6 +297,7 @@ public final class Hue {
 
   /**
    * Returns all the motion sensors configured into the Bridge.
+   * For easy of use geofence sensors are considered motion sensors as well.
    *
    * @return A Collection of motion sensors.
    * @since 1.0.0
@@ -340,6 +341,7 @@ public final class Hue {
 
   /**
    * Returns a specific motion sensor by its name.
+   * For easy of use geofence sensors are considered motion sensors as well.
    *
    * @param sensorName The name of a sensor
    * @return A sensor or {@code Optional.empty()} if a sensor with the given name does not exist.

--- a/src/main/java/io/github/zeroone3010/yahueapi/SensorType.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/SensorType.java
@@ -10,7 +10,7 @@ public enum SensorType {
   TEMPERATURE,
 
   /**
-   * A motion sensor, i.e. either a ZLLPresence or a CLIPPresence sensor.
+   * A motion sensor, i.e. either a ZLLPresence, a CLIPPresence or a Geofence sensor.
    */
   MOTION,
 
@@ -42,6 +42,8 @@ public enum SensorType {
       case "zllpresence":
         return MOTION;
       case "clippresence":
+        return MOTION;
+      case "geofence":
         return MOTION;
       case "zllswitch":
         return SWITCH;


### PR DESCRIPTION
Hello everyone

I'm currently building a small home automation project and while playing around I noticed that Geofencing sensors are not recognised by this API. So i thought why not add them since they are very similar to other motion sensors 😃.

`{
    "state": {
        "presence": true,
        "lastupdated": "2021-01-18T04:27:33"
    },
    "config": {
        "on": true,
        "reachable": true
    },
    "name": "Google Pixel 4 XL",
    "type": "Geofence",
    "modelid": "HA_GEOFENCE",
    "manufacturername": "Philips",
    "swversion": "A_1",
    "uniqueid": "L_02_2DbfL",
    "recycle": true
}`

Kind Regards