### PR TITLE
Switch from java.util.logging to slf4j

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,7 +171,12 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.13.1</version>
+            <version>2.13.2</version>
+        </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <version>${slf4j.version}</version>
         </dependency>
 
         <dependency>
@@ -192,12 +197,19 @@
             <version>2.32.0</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-simple</artifactId>
+            <version>${slf4j.version}</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <properties>
         <maven.compiler.target>1.8</maven.compiler.target>
         <maven.compiler.source>1.8</maven.compiler.source>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <slf4j.version>1.7.36</slf4j.version>
     </properties>
 
     <licenses>

--- a/src/main/java/io/github/zeroone3010/yahueapi/BasicSensor.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/BasicSensor.java
@@ -1,15 +1,16 @@
 package io.github.zeroone3010.yahueapi;
 
 import io.github.zeroone3010.yahueapi.domain.SensorDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URL;
 import java.time.ZonedDateTime;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 class BasicSensor implements Sensor {
-  private static final Logger logger = Logger.getLogger("io.github.zeroone3010.yahueapi");
+  private static final Logger logger = LoggerFactory.getLogger(BasicSensor.class);
   private static final String NO_LAST_UPDATED_DATA = "none";
 
   protected final String id;
@@ -62,7 +63,7 @@ class BasicSensor implements Sensor {
 
   protected <T> T readStateValue(final String stateValueKey, final Class<T> type) {
     final Map<String, Object> state = stateProvider.get();
-      logger.fine(state.toString());
+      logger.debug(state.toString());
       return type.cast(state.get(stateValueKey));
   }
 

--- a/src/main/java/io/github/zeroone3010/yahueapi/DaylightSensorImpl.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/DaylightSensorImpl.java
@@ -1,15 +1,15 @@
 package io.github.zeroone3010.yahueapi;
 
 import io.github.zeroone3010.yahueapi.domain.SensorDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.net.URL;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 final class DaylightSensorImpl extends BasicSensor implements DaylightSensor {
-  private static final Logger logger = Logger.getLogger("io.github.zeroone3010.yahueapi");
+  private static final Logger logger = LoggerFactory.getLogger(DaylightSensorImpl.class);
 
   DaylightSensorImpl(final String id, final SensorDto sensor, final URL url, final Supplier<Map<String, Object>> stateProvider) {
     super(id, sensor, url, stateProvider);
@@ -29,7 +29,7 @@ final class DaylightSensorImpl extends BasicSensor implements DaylightSensor {
     try {
       return readStateValue("daylight", Boolean.class);
     } catch (final NullPointerException npe) {
-      logger.log(Level.WARNING, "It appears that the daylight sensor has not been configured.");
+      logger.warn("It appears that the daylight sensor has not been configured.");
       return false;
     }
   }

--- a/src/main/java/io/github/zeroone3010/yahueapi/Hue.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/Hue.java
@@ -8,6 +8,8 @@ import io.github.zeroone3010.yahueapi.domain.ApiInitializationStatus;
 import io.github.zeroone3010.yahueapi.domain.Group;
 import io.github.zeroone3010.yahueapi.domain.Root;
 import io.github.zeroone3010.yahueapi.domain.Scene;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -25,7 +27,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import static io.github.zeroone3010.yahueapi.RoomFactory.ALL_LIGHTS_GROUP_ID;
@@ -40,7 +41,7 @@ import static java.util.stream.Collectors.toSet;
  * with which one can get all the lights, sensors, rooms, etc. to interact with them.
  */
 public final class Hue {
-  private static final Logger logger = Logger.getLogger("io.github.zeroone3010.yahueapi");
+  private static final Logger logger = LoggerFactory.getLogger(Hue.class);
 
   private static final int EXPECTED_NEW_LIGHTS_SEARCH_TIME_IN_SECONDS = 50;
 
@@ -536,7 +537,7 @@ public final class Hue {
           if (light != null) {
             newLights.add(light);
           } else {
-            logger.warning("New light " + lightIdField + " not found, but it was expected.");
+            logger.warn("New light {} not found, but it was expected.", lightIdField);
           }
         }
         break;

--- a/src/main/java/io/github/zeroone3010/yahueapi/LightImpl.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/LightImpl.java
@@ -2,13 +2,14 @@ package io.github.zeroone3010.yahueapi;
 
 import io.github.zeroone3010.yahueapi.domain.LightDto;
 import io.github.zeroone3010.yahueapi.domain.LightState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 final class LightImpl implements Light {
-  private static final Logger logger = Logger.getLogger("io.github.zeroone3010.yahueapi");
+  private static final Logger logger = LoggerFactory.getLogger(LightImpl.class);
 
   private final String id;
   private final String name;
@@ -62,7 +63,7 @@ final class LightImpl implements Light {
 
   private LightState getLightState() {
     final LightState state = stateProvider.get();
-    logger.fine(state.toString());
+    logger.debug(state.toString());
     return state;
   }
 
@@ -74,7 +75,7 @@ final class LightImpl implements Light {
   @Override
   public void setState(final State state) {
     final String result = stateSetter.apply(state);
-    logger.fine(result);
+    logger.debug(result);
   }
 
   @Override

--- a/src/main/java/io/github/zeroone3010/yahueapi/RoomImpl.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/RoomImpl.java
@@ -3,6 +3,8 @@ package io.github.zeroone3010.yahueapi;
 import io.github.zeroone3010.yahueapi.StateBuilderSteps.BrightnessStep;
 import io.github.zeroone3010.yahueapi.domain.Group;
 import io.github.zeroone3010.yahueapi.domain.GroupState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Collection;
 import java.util.HashSet;
@@ -11,12 +13,11 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import java.util.logging.Logger;
 
 import static java.util.stream.Collectors.toSet;
 
 final class RoomImpl implements Room {
-  private static final Logger logger = Logger.getLogger("io.github.zeroone3010.yahueapi");
+  private static final Logger logger = LoggerFactory.getLogger(RoomImpl.class);
 
   private final String id;
   private final Supplier<Set<Light>> lights;
@@ -89,7 +90,7 @@ final class RoomImpl implements Room {
   @Override
   public void setState(final State state) {
     final String result = stateSetter.apply(state);
-    logger.fine(result);
+    logger.debug(result);
   }
 
   @Override
@@ -121,7 +122,7 @@ final class RoomImpl implements Room {
   @Override
   public Collection<Light> addLight(final Light newLight) {
     if (newLight == null || newLight.getId() == null) {
-      logger.warning("addLight: Given light was null. Doing nothing.");
+      logger.warn("addLight: Given light was null. Doing nothing.");
       return getLights();
     }
 
@@ -135,13 +136,13 @@ final class RoomImpl implements Room {
   @Override
   public Collection<Light> removeLight(final Light lightToBeRemoved) {
     if (lightToBeRemoved == null || lightToBeRemoved.getId() == null) {
-      logger.warning("removeLight: Given light was null. Doing nothing.");
+      logger.warn("removeLight: Given light was null. Doing nothing.");
       return getLights();
     }
     final Set<String> lightIds = new HashSet<>(getLights().stream().map(Light::getId).collect(toSet()));
     lightIds.remove(lightToBeRemoved.getId());
     final String result = lightsSetter.apply(lightIds);
-    logger.fine(result);
+    logger.debug(result);
     return getLights();
   }
 

--- a/src/main/java/io/github/zeroone3010/yahueapi/State.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/State.java
@@ -16,19 +16,20 @@ import io.github.zeroone3010.yahueapi.StateBuilderSteps.SaturationStep;
 import io.github.zeroone3010.yahueapi.StateBuilderSteps.TransitionTimeStep;
 import io.github.zeroone3010.yahueapi.StateBuilderSteps.XyStep;
 import io.github.zeroone3010.yahueapi.domain.LightState;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.logging.Logger;
 
 import static io.github.zeroone3010.yahueapi.MathUtil.isInRange;
 
 @JsonInclude(Include.NON_NULL)
 public final class State {
-  private static final Logger logger = Logger.getLogger("io.github.zeroone3010.yahueapi");
+  private static final Logger logger = LoggerFactory.getLogger(State.class);
 
   private static final int DIMMABLE_LIGHT_COLOR_TEMPERATURE = 370;
 
@@ -172,7 +173,7 @@ public final class State {
   }
 
   static State build(final LightState state) {
-    logger.fine(state.toString());
+    logger.debug(state.toString());
     final InitialStep builder = new State.Builder(AlertType.parseTypeString(state.getAlert()));
     if (state.getColorMode() == null) {
       return builder.colorTemperatureInMireks(DIMMABLE_LIGHT_COLOR_TEMPERATURE).brightness(state.getBrightness()).on(state.isOn());

--- a/src/main/java/io/github/zeroone3010/yahueapi/TemperatureSensorImpl.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/TemperatureSensorImpl.java
@@ -1,17 +1,17 @@
 package io.github.zeroone3010.yahueapi;
 
 import io.github.zeroone3010.yahueapi.domain.SensorDto;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.net.URL;
 import java.util.Map;
 import java.util.function.Supplier;
-import java.util.logging.Level;
-import java.util.logging.Logger;
 
 final class TemperatureSensorImpl extends BasicSensor implements TemperatureSensor {
-  private static final Logger logger = Logger.getLogger("io.github.zeroone3010.yahueapi");
+  private static final Logger logger = LoggerFactory.getLogger(TemperatureSensorImpl.class);
 
   TemperatureSensorImpl(final String id, final SensorDto sensor, final URL url, final Supplier<Map<String, Object>> stateProvider) {
     super(id, sensor, url, stateProvider);
@@ -31,7 +31,7 @@ final class TemperatureSensorImpl extends BasicSensor implements TemperatureSens
     try {
       return convertCenticelsiusToCelsius(readStateValue("temperature", Integer.class));
     } catch (NullPointerException npe) {
-      logger.log(Level.WARNING, "It appears that the temperature sensor may be disabled.");
+      logger.warn("It appears that the temperature sensor may be disabled.");
       return null;
     }
   }

--- a/src/main/java/io/github/zeroone3010/yahueapi/TrustEverythingManager.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/TrustEverythingManager.java
@@ -1,5 +1,8 @@
 package io.github.zeroone3010.yahueapi;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.net.ssl.HttpsURLConnection;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.TrustManager;
@@ -8,10 +11,9 @@ import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.SecureRandom;
 import java.security.cert.X509Certificate;
-import java.util.logging.Logger;
 
 public class TrustEverythingManager implements X509TrustManager {
-  private static final Logger logger = Logger.getLogger("io.github.zeroone3010.yahueapi");
+  private static final Logger logger = LoggerFactory.getLogger(TrustEverythingManager.class);
 
   public X509Certificate[] getAcceptedIssuers() {
     return new X509Certificate[]{};
@@ -27,12 +29,12 @@ public class TrustEverythingManager implements X509TrustManager {
 
   public static void trustAllSslConnectionsByDisablingCertificateVerification() {
     try {
-      logger.fine("Turning off certificate verification...");
+      logger.debug("Turning off certificate verification...");
       final SSLContext sslContext = SSLContext.getInstance("SSL");
       sslContext.init(null, new TrustManager[]{new TrustEverythingManager()}, new SecureRandom());
       HttpsURLConnection.setDefaultSSLSocketFactory(sslContext.getSocketFactory());
       HttpsURLConnection.setDefaultHostnameVerifier((hostname, session) -> true);
-      logger.fine("Certificate verification has been turned off, all certificates are now accepted.");
+      logger.debug("Certificate verification has been turned off, all certificates are now accepted.");
     } catch (final NoSuchAlgorithmException | KeyManagementException e) {
       throw new HueApiException(e);
     }

--- a/src/main/java/io/github/zeroone3010/yahueapi/discovery/HueBridgeDiscoveryService.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/discovery/HueBridgeDiscoveryService.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import io.github.zeroone3010.yahueapi.HueBridge;
 import io.github.zeroone3010.yahueapi.TrustEverythingManager;
 import io.github.zeroone3010.yahueapi.domain.BridgeConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.URL;
@@ -17,7 +19,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Future;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import java.util.logging.Logger;
 import java.util.stream.Stream;
 
 import static java.util.Arrays.asList;
@@ -26,7 +27,7 @@ import static java.util.Arrays.asList;
  * A service with which one can discover the available Hue Bridges.
  */
 public final class HueBridgeDiscoveryService {
-  private static final Logger logger = Logger.getLogger("io.github.zeroone3010.yahueapi");
+  private static final Logger logger = LoggerFactory.getLogger(HueBridgeDiscoveryService.class);
 
   /**
    * The different methods that one can use to discover the available bridges.
@@ -137,7 +138,7 @@ public final class HueBridgeDiscoveryService {
       TrustEverythingManager.trustAllSslConnectionsByDisablingCertificateVerification();
       return objectMapper.readValue(new URL("https://" + ip + "/api/config"), BridgeConfig.class);
     } catch (final IOException e) {
-      logger.severe("Unable to connect to a found Bridge at " + ip + ": " + e);
+      logger.error("Unable to connect to a found Bridge at " + ip + ": " + e);
       return null;
     }
   }

--- a/src/main/java/io/github/zeroone3010/yahueapi/discovery/MDNSDiscoverer.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/discovery/MDNSDiscoverer.java
@@ -1,6 +1,8 @@
 package io.github.zeroone3010.yahueapi.discovery;
 
 import io.github.zeroone3010.yahueapi.HueBridge;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
@@ -14,14 +16,13 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.logging.Logger;
 
 /**
  * Discovers Hue Bridges using the mDNS protocol, i.e. by sending out multicast DNS queries
  * and waiting for any Bridges to respond.
  */
 final class MDNSDiscoverer implements HueBridgeDiscoverer {
-  private static final Logger logger = Logger.getLogger("io.github.zeroone3010.yahueapi");
+  private static final Logger logger = LoggerFactory.getLogger(MDNSDiscoverer.class);
 
   private static final int DISCOVERY_MESSAGE_COUNT = 5;
   private static final int PORT = 5353;
@@ -108,7 +109,7 @@ final class MDNSDiscoverer implements HueBridgeDiscoverer {
           state = DiscoverState.CRASHED;
           e.printStackTrace();
         } catch (final MDNSException e) {
-          logger.warning(e.getMessage());
+          logger.warn(e.getMessage());
         } finally {
           stop();
         }
@@ -131,7 +132,7 @@ final class MDNSDiscoverer implements HueBridgeDiscoverer {
   private void packetHandler(final DatagramPacket packet) {
     final MDNSResponseParser parser = new MDNSResponseParser(packet, Arrays.asList("_hue", "_tcp", "local"));
     final String ip = parser.parse();
-    logger.fine(String.format("Got MDNS response '%s' from '%s'", ip, packet.getAddress()));
+    logger.debug("Got MDNS response '{}' from '{}'", ip, packet.getAddress());
     discoverer.accept(new HueBridge(ip));
   }
 

--- a/src/main/java/io/github/zeroone3010/yahueapi/discovery/MDNSResponseParser.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/discovery/MDNSResponseParser.java
@@ -1,5 +1,8 @@
 package io.github.zeroone3010.yahueapi.discovery;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.net.DatagramPacket;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -7,13 +10,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.logging.Logger;
 
 /**
  * MDNS response parser for parsing MDNS responses from the Bridge when using the MDNS discovery protocol.
  */
 final class MDNSResponseParser {
-  private static final Logger logger = Logger.getLogger("io.github.zeroone3010.yahueapi");
+  private static final Logger logger = LoggerFactory.getLogger(MDNSResponseParser.class);
 
   private static final int EXPECTED_QUESTION_COUNT = 0x01;
   private static final int EXPECTED_ANSWER_COUNT = 0x01;
@@ -114,7 +116,7 @@ final class MDNSResponseParser {
       labels.add(label.toString());
       names.put(questionNameLocation, labels);
     }
-    logger.fine("Names: " + names);
+    logger.debug("Names: " + names);
     final List<String> actualNames = names.get(questionNameLocation);
     if (expected != null && !Objects.equals(actualNames, expected)) {
       throw new MDNSException("Expected to see " + expected + " as labels, got " + actualNames + " instead.");
@@ -140,7 +142,7 @@ final class MDNSResponseParser {
       // It's a compressed field, the next byte (and the six least significant bits of this byte) is a pointer
       bytePointer++;
       int pointer = ((data[bytePointer - 1] & 0b00111111) << 8) | data[bytePointer++];
-      logger.fine("The answer has a pointer to " + pointer + " which means " + names.get(pointer));
+      logger.debug("The answer has a pointer to " + pointer + " which means " + names.get(pointer));
     } else {
       matchNames(expected);
     }

--- a/src/main/java/io/github/zeroone3010/yahueapi/discovery/NUPnPDiscoverer.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/discovery/NUPnPDiscoverer.java
@@ -8,6 +8,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import io.github.zeroone3010.yahueapi.HueBridge;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -16,14 +18,13 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
-import java.util.logging.Logger;
 
 /**
  * Discovers Hue Bridges using the N-UPnP protocol, i.e. by polling the Philips Hue portal
  * that stores the external and internal IP addresses of the Bridge.
  */
 final class NUPnPDiscoverer implements HueBridgeDiscoverer {
-  private static final Logger logger = Logger.getLogger("io.github.zeroone3010.yahueapi");
+  private static final Logger logger = LoggerFactory.getLogger(NUPnPDiscoverer.class);
 
   private static final String HUE_DISCOVERY_PORTAL = "https://discovery.meethue.com/";
   private static final String DEFAULT_TIMEOUT_MILLISECONDS = "4000";
@@ -56,7 +57,7 @@ final class NUPnPDiscoverer implements HueBridgeDiscoverer {
     try {
       return Integer.valueOf(string);
     } catch (final NumberFormatException e) {
-      logger.warning(String.format("'%s' is not a valid timeout value", string));
+      logger.warn("'{}' is not a valid timeout value", string);
       return -1;
     }
   }
@@ -75,11 +76,11 @@ final class NUPnPDiscoverer implements HueBridgeDiscoverer {
     objectMapper.registerModule(module);
     return CompletableFuture.supplyAsync(() -> {
       try {
-        logger.fine("Discovering Bridges using the Philips Hue Portal.");
+        logger.debug("Discovering Bridges using the Philips Hue Portal.");
         final List<HueBridge> foundBridges = objectMapper.<ArrayList<HueBridge>>readValue(url,
             new TypeReference<ArrayList<HueBridge>>() {
             });
-        logger.info(String.format("%d Bridges found using the portal.", foundBridges.size()));
+        logger.info("{} Bridges found using the portal.", foundBridges.size());
         foundBridges.forEach(discoverer);
       } catch (final IOException e) {
         throw new RuntimeException(e);

--- a/src/main/java/io/github/zeroone3010/yahueapi/discovery/UPnPDiscoverer.java
+++ b/src/main/java/io/github/zeroone3010/yahueapi/discovery/UPnPDiscoverer.java
@@ -1,6 +1,8 @@
 package io.github.zeroone3010.yahueapi.discovery;
 
 import io.github.zeroone3010.yahueapi.HueBridge;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.net.DatagramPacket;
@@ -13,7 +15,6 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
-import java.util.logging.Logger;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -26,7 +27,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 @Deprecated
 final class UPnPDiscoverer implements HueBridgeDiscoverer {
-  private static final Logger logger = Logger.getLogger("io.github.zeroone3010.yahueapi");
+  private static final Logger logger = LoggerFactory.getLogger(UPnPDiscoverer.class);
 
   private static final int DISCOVERY_MESSAGE_COUNT = 5;
   private static final int DEFAULT_PORT = 1900;
@@ -110,7 +111,7 @@ final class UPnPDiscoverer implements HueBridgeDiscoverer {
       requestSendTask = scheduledExecutorService.schedule(() -> {
         try {
           for (int i = 0; i < DISCOVERY_MESSAGE_COUNT; i++) {
-            logger.fine("Sending a discovery message");
+            logger.debug("Sending a discovery message");
             socket.send(requestPacket);
             TimeUnit.MILLISECONDS.sleep(MILLISECONDS_BETWEEN_DISCOVERY_MESSAGES);
           }


### PR DESCRIPTION
Replaced all java util logging calls with the equivalent slf4j methods. Every class also has it's own logger, which allows fine configuration via any logging framework.
Uses slf4j-simple implementation for testing purposes.